### PR TITLE
Fix exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ The return code of the child process is returned in the second argument (stored
 into `process_return` in the example above). This parameter can be `NULL` if you
 don't care about the process' return code.
 
+If the child process encounters an unhandled exception, the return code will always
+be filled with a _non zero_ value.
+
 ### Destroying a Process
 
 To destroy a previously created process you call `subprocess_destroy` like so:

--- a/subprocess.h
+++ b/subprocess.h
@@ -525,7 +525,7 @@ int subprocess_join(struct subprocess_s *const process,
     if (WIFEXITED(status)) {
       *out_return_code = WEXITSTATUS(status);
     } else {
-      *out_return_code = 0;
+      *out_return_code = EXIT_FAILURE;
     }
   }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,6 +40,8 @@ add_executable(process_stderr_argc process_stderr_argc.c)
 add_executable(process_stderr_argv process_stderr_argv.c)
 add_executable(process_combined_stdout_stderr process_combined_stdout_stderr.c)
 add_executable(process_inherit_environment process_inherit_environment.c)
+add_executable(process_fail_divzero process_fail_divzero.c)
+add_executable(process_fail_stackoverflow process_fail_stackoverflow.c)
 
 add_executable(subprocess_test
   ../subprocess.h

--- a/test/main.c
+++ b/test/main.c
@@ -359,4 +359,27 @@ UTEST(create, subprocess_inherit_all_environment) {
   ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
+UTEST(create, subprocess_fail_divzero) {
+  const char *const commandLine[] = {"./process_fail_divzero", 0};
+  struct subprocess_s process;
+  int ret = -1;
+
+  ASSERT_EQ(0,subprocess_create(commandLine, 0, &process));
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
+  ASSERT_EQ(0, subprocess_destroy(&process));
+  ASSERT_EQ(ret, EXIT_FAILURE);
+}
+
+UTEST(create, subprocess_fail_stackoverflow) {
+  const char *const commandLine[] = {"./process_fail_stackoverflow", 0};
+  struct subprocess_s process;
+  int ret = -1;
+
+  ASSERT_EQ(0,subprocess_create(commandLine, 0, &process));
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
+  ASSERT_EQ(0, subprocess_destroy(&process));
+  ASSERT_EQ(ret, EXIT_FAILURE);
+}
+
+
 UTEST_MAIN()

--- a/test/main.c
+++ b/test/main.c
@@ -367,7 +367,7 @@ UTEST(create, subprocess_fail_divzero) {
   ASSERT_EQ(0,subprocess_create(commandLine, 0, &process));
   ASSERT_EQ(0, subprocess_join(&process, &ret));
   ASSERT_EQ(0, subprocess_destroy(&process));
-  ASSERT_EQ(ret, EXIT_FAILURE);
+  ASSERT_NE(ret, 0);
 }
 
 UTEST(create, subprocess_fail_stackoverflow) {
@@ -378,7 +378,7 @@ UTEST(create, subprocess_fail_stackoverflow) {
   ASSERT_EQ(0,subprocess_create(commandLine, 0, &process));
   ASSERT_EQ(0, subprocess_join(&process, &ret));
   ASSERT_EQ(0, subprocess_destroy(&process));
-  ASSERT_EQ(ret, EXIT_FAILURE);
+  ASSERT_NE(ret, 0);
 }
 
 

--- a/test/process_fail_divzero.c
+++ b/test/process_fail_divzero.c
@@ -11,9 +11,12 @@ int return_0_non_optimizable()
 {
   char buffer[100];
   long value = 62831853;
+  char *c;
+  int result;
+
   sprintf(buffer, "%ld", value);
-  char *c = buffer;
-  int result = 0;
+  c = buffer;
+  result = 0;
   while (*c) {
     int digit = (int)(c[0] - '0');
     result = result + digit;
@@ -24,9 +27,11 @@ int return_0_non_optimizable()
 
 int main()
 {
-  int p = 42;
-  int q = return_0_non_optimizable();
-  int r = p / q; // this is an integer division by zero
+  int p, q, r;
+
+  p = 42;
+  q = return_0_non_optimizable();
+  r = p / q; // this is an integer division by zero
   printf("r=%d\n", r);
   return 0;
 }

--- a/test/process_fail_divzero.c
+++ b/test/process_fail_divzero.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <math.h>
+
+int main()
+{
+    int p = (int)cos(0.);
+    int q = (int)sin(0.);
+    int r = p / q; // this is an integer division by zero
+    printf("%d", r);
+    return 0;
+}

--- a/test/process_fail_divzero.c
+++ b/test/process_fail_divzero.c
@@ -1,22 +1,25 @@
-
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+
+#ifdef _MSC_VER
+#pragma warning(disable:4996)
+#endif // _MSC_VER
+
 
 // This convoluted function returns 0
-// but will hopefuly not be optimzed away in release builds...
+// but will hopefully not be optimized away in release builds...
 int return_0_non_optimizable()
 {
   char buffer[100];
-  long value = 62831853071796;
-  snprintf(buffer, 100, "%ld", value);
+  long value = 62831853;
+  sprintf(buffer, "%ld", value);
   char *c = buffer;
   int result = 0;
   while (*c) {
-    result = result + *c - '\0';
+    int digit = (int)(c[0] - '0');
+    result = result + digit;
     c++;
   }
-  return result - 738;
+  return result - 36;
 }
 
 int main()

--- a/test/process_fail_divzero.c
+++ b/test/process_fail_divzero.c
@@ -1,10 +1,9 @@
 #include <stdio.h>
-#include <math.h>
 
 int main()
 {
-    int p = (int)cos(0.);
-    int q = (int)sin(0.);
+    int p = 42;
+    int q = p - 2 * 21;
     int r = p / q; // this is an integer division by zero
     printf("%d", r);
     return 0;

--- a/test/process_fail_divzero.c
+++ b/test/process_fail_divzero.c
@@ -1,10 +1,29 @@
+
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// This convoluted function returns 0
+// but will hopefuly not be optimzed away in release builds...
+int return_0_non_optimizable()
+{
+  char buffer[100];
+  long value = 62831853071796;
+  snprintf(buffer, 100, "%ld", value);
+  char *c = buffer;
+  int result = 0;
+  while (*c) {
+    result = result + *c - '\0';
+    c++;
+  }
+  return result - 738;
+}
 
 int main()
 {
-    int p = 42;
-    int q = p - 2 * 21;
-    int r = p / q; // this is an integer division by zero
-    printf("%d", r);
-    return 0;
+  int p = 42;
+  int q = return_0_non_optimizable();
+  int r = p / q; // this is an integer division by zero
+  printf("r=%d\n", r);
+  return 0;
 }

--- a/test/process_fail_stackoverflow.c
+++ b/test/process_fail_stackoverflow.c
@@ -10,9 +10,12 @@ int return_0_non_optimizable()
 {
   char buffer[100];
   long value = 62831853;
+  char *c;
+  int result;
+
   sprintf(buffer, "%ld", value);
-  char *c = buffer;
-  int result = 0;
+  c = buffer;
+  result = 0;
   while (*c) {
     int digit = (int)(c[0] - '0');
     result = result + digit;
@@ -34,6 +37,7 @@ int fun(int x) {
 int main(){
   int x = 5;
   int y;
+
   y = fun(x);
   printf("%d", y);
   return 0;

--- a/test/process_fail_stackoverflow.c
+++ b/test/process_fail_stackoverflow.c
@@ -1,21 +1,25 @@
 #include <stdio.h>
  
+#ifdef _MSC_VER
+#pragma warning(disable:4996)
+#endif // _MSC_VER
+
 // This convoluted function returns 0
-// but will hopefuly not be optimzed away in release builds...
+// but will hopefully not be optimized away in release builds...
 int return_0_non_optimizable()
 {
   char buffer[100];
-  long value = 62831853071796;
-  snprintf(buffer, 100, "%ld", value);
+  long value = 62831853;
+  sprintf(buffer, "%ld", value);
   char *c = buffer;
   int result = 0;
   while (*c) {
-    result = result + *c - '\0';
+    int digit = (int)(c[0] - '0');
+    result = result + digit;
     c++;
   }
-  return result - 738;
+  return result - 36;
 }
-
 
 // this function is infinitely recursive and will cause a stack overflow
 int fun(int x) { 

--- a/test/process_fail_stackoverflow.c
+++ b/test/process_fail_stackoverflow.c
@@ -1,11 +1,29 @@
 #include <stdio.h>
  
+// This convoluted function returns 0
+// but will hopefuly not be optimzed away in release builds...
+int return_0_non_optimizable()
+{
+  char buffer[100];
+  long value = 62831853071796;
+  snprintf(buffer, 100, "%ld", value);
+  char *c = buffer;
+  int result = 0;
+  while (*c) {
+    result = result + *c - '\0';
+    c++;
+  }
+  return result - 738;
+}
+
+
 // this function is infinitely recursive and will cause a stack overflow
 int fun(int x) { 
   if (x == 1) 
       return 5;
   x = 6; 
-  fun(x);
+  if (return_0_non_optimizable() == 0)
+    fun(x);
   return x;
 } 
 

--- a/test/process_fail_stackoverflow.c
+++ b/test/process_fail_stackoverflow.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+ 
+// this function is infinitely recursive and will cause a stack overflow
+int fun(int x) { 
+  if (x == 1) 
+      return 5;
+  x = 6; 
+  fun(x);
+  return x;
+} 
+
+int main(){
+  int x = 5;
+  int y;
+  y = fun(x);
+  printf("%d", y);
+  return 0;
+}

--- a/test/process_inherit_environment.c
+++ b/test/process_inherit_environment.c
@@ -26,6 +26,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _MSC_VER
+#pragma warning(disable:4996)
+#endif // _MSC_VER
+
 int main(int argc, const char *const argv[], const char *const envp[]) {
   if ((1 < argc) && (0 == strcmp(argv[1], "all"))) {
     if (0 == *envp) {


### PR DESCRIPTION
Hi,

Here is a PR that proposes a potential fix for the issue https://github.com/sheredom/subprocess.h/issues/17
I had to fight against the optimizer, so that I get consistent failure in optimized build, so the repro code looks like this: https://github.com/pthom/subprocess.h/blob/fix_exit/test/process_fail_divzero.c

The only guarantee the code can make is that if the child process encounters an unhandled exception, the return code will always be filled with a _non zero_ value.

CI build here: 
* https://travis-ci.org/pthom/subprocess.h/builds/639956557?utm_source=github_status
* https://ci.appveyor.com/project/pthom/subprocess-h/builds/30258555

