### PR TITLE
Close handles early on windows to allow reading lots of data.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,8 @@ add_executable(process_inherit_environment process_inherit_environment.c)
 add_executable(process_fail_divzero process_fail_divzero.c)
 add_executable(process_fail_stackoverflow process_fail_stackoverflow.c)
 add_executable(process_hung process_hung.c)
+add_executable(process_stdout_data process_stdout_data.c)
+add_executable(process_stdout_poll process_stdout_poll.c)
 
 add_executable(subprocess_test
   ../subprocess.h

--- a/test/process_stdout_data.c
+++ b/test/process_stdout_data.c
@@ -1,0 +1,47 @@
+// This is free and unencumbered software released into the public domain.
+//
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non-commercial, and by any
+// means.
+//
+// In jurisdictions that recognize copyright laws, the author or authors
+// of this software dedicate any and all copyright interest in the
+// software to the public domain. We make this dedication for the benefit
+// of the public at large and to the detriment of our heirs and
+// successors. We intend this dedication to be an overt act of
+// relinquishment in perpetuity of all present and future rights to this
+// software under copyright law.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// For more information, please refer to <http://unlicense.org/>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#if defined(_MSC_VER)
+__declspec(dllimport) void __stdcall Sleep(unsigned long);
+#else
+#include <unistd.h>
+#endif
+
+int main(int argc, const char *const argv[]) {
+  int i;
+  int e = atoi(argv[1]);
+  #if defined(_MSC_VER)
+  Sleep(2000);
+#else
+  sleep(2);
+#endif
+  for (i = 0; i < e; i++) {
+    printf("%x", i % 16);
+  }
+  return 0;
+}

--- a/test/process_stdout_poll.c
+++ b/test/process_stdout_poll.c
@@ -1,0 +1,36 @@
+// This is free and unencumbered software released into the public domain.
+//
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non-commercial, and by any
+// means.
+//
+// In jurisdictions that recognize copyright laws, the author or authors
+// of this software dedicate any and all copyright interest in the
+// software to the public domain. We make this dedication for the benefit
+// of the public at large and to the detriment of our heirs and
+// successors. We intend this dedication to be an overt act of
+// relinquishment in perpetuity of all present and future rights to this
+// software under copyright law.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// For more information, please refer to <http://unlicense.org/>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, const char *const argv[]) {
+  int index;
+  const int max = atoi(argv[1]);
+
+  for (index = 0; index < max; index++) {
+    printf("Hello, world!");
+  }
+}


### PR DESCRIPTION
I set out in this commit to get polling to work (being able to read from
a process before its actually complete) - and utterly failed. Instead I
think I've worked out how to get Windows to not lock up on reading any
amount of data from the subprocess, which I think fixes #16.

Fixes #16.