### PR TITLE
Add an asynchronous reading API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ process for instance.
 
 ### Terminating a Process
 
-To terminate a (possibly hung) previously created process you call `subprocess_terminate` like so:
+To terminate a (possibly hung) previously created process you call
+`subprocess_terminate` like so:
 
 ```c
 int result = subprocess_terminate(&process);
@@ -129,8 +130,22 @@ if (0 != result) {
 }
 ```
 
-Note that you still can call `subprocess_destroy`, and `subprocess_join` after calling `subprocess_terminate`;
-and that the return code filled by `subprocess_join(&process, &process_return)` is then guaranted to be _non zero_.
+Note that you still can call `subprocess_destroy`, and `subprocess_join` after
+calling `subprocess_terminate`, and that the return code filled by
+`subprocess_join(&process, &process_return)` is then guaranted to be _non zero_.
+
+### Reading Asynchronously
+
+If you want to be able to read from a process _before_ calling `subprocess_join`
+on it, you cannot use `subprocess_stdout` or `subprocess_stderr` because the
+various operating systems that this library supports do not allow for this.
+
+Instead you first have to call `subprocess_create` and specify the
+`subprocess_option_enable_async` option - which enables asynchronous reading.
+
+Then you must use the `subprocess_read_stdout` and `subprocess_read_stderr`
+helper functions to do any reading from either pipe. Note that these calls _may_
+block if there isn't any data ready to be read.
 
 ## Todo
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,6 +45,8 @@ add_executable(process_fail_stackoverflow process_fail_stackoverflow.c)
 add_executable(process_hung process_hung.c)
 add_executable(process_stdout_data process_stdout_data.c)
 add_executable(process_stdout_poll process_stdout_poll.c)
+add_executable(process_stderr_poll process_stderr_poll.c)
+add_executable(process_stdout_large process_stdout_large.c)
 
 add_executable(subprocess_test
   ../subprocess.h

--- a/test/process_stderr_poll.c
+++ b/test/process_stderr_poll.c
@@ -32,7 +32,7 @@ int main(int argc, const char *const argv[]) {
 
   do {
     for (index = 0; index < max; index++) {
-      printf("Hello, world!");
+      fprintf(stderr, "Hello, world!");
     }
   } while (fgetc(stdin) != 's');
 

--- a/test/process_stdout_large.c
+++ b/test/process_stdout_large.c
@@ -30,11 +30,9 @@ int main(int argc, const char *const argv[]) {
   int index;
   const int max = atoi(argv[1]);
 
-  do {
-    for (index = 0; index < max; index++) {
-      printf("Hello, world!");
-    }
-  } while (fgetc(stdin) != 's');
+  for (index = 0; index < max; index++) {
+    printf("Hello, world!");
+  }
 
   return 0;
 }


### PR DESCRIPTION
This commit adds an asynchronous reading API to let you get the
stdout or stderr of a process while the process is still running.

You cannot use normal C FILE API operations for this - so instead
I've had to add new `subprocess_read_stdout` and
`subprocess_read_stderr` helper functions and a
`subprocess_option_enable_async` option to `subprocess_create` to enable
this functionality.