### PR TITLE
Fix a bug when /MT was used on Windows.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,8 @@ environment:
     - VSVERSION: Visual Studio 14 2015
     - VSVERSION: Visual Studio 15 2017
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - VSVERSION: Visual Studio 16 2019
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
 
 platform:
   - Win32
@@ -32,8 +34,10 @@ configuration:
 build_script:
   - md build
   - cd build
-  - if "%PLATFORM%"=="x64" cmake -G "%VSVERSION% Win64" ../test
-  - if "%PLATFORM%"=="Win32" cmake -G "%VSVERSION%" ../test
+  - if NOT "%VSVERSION%"=="Visual Studio 16 2019" if "%PLATFORM%"=="x64" cmake -G "%VSVERSION% Win64" ../test
+  - if NOT "%VSVERSION%"=="Visual Studio 16 2019" if "%PLATFORM%"=="Win32" cmake -G "%VSVERSION%" ../test
+  - if "%VSVERSION%"=="Visual Studio 16 2019" cmake -G "%VSVERSION%" -A "%PLATFORM%" ../test
   - msbuild /m /p:Configuration="%CONFIGURATION%" /p:Platform="%PLATFORM%" process.sln
   - cd %CONFIGURATION%
   - subprocess_test.exe
+  - subprocess_mt_test.exe

--- a/subprocess.h
+++ b/subprocess.h
@@ -274,14 +274,22 @@ __declspec(dllimport) int __stdcall GetExitCodeProcess(
     void *, unsigned long *lpExitCode);
 __declspec(dllimport) int __stdcall TerminateProcess(
   void *, unsigned int);
-__declspec(dllimport) int __cdecl _open_osfhandle(subprocess_intptr_t, int);
-__declspec(dllimport) subprocess_intptr_t __cdecl _get_osfhandle(int);
-void *__cdecl _alloca(subprocess_size_t);
 __declspec(dllimport) unsigned long __stdcall WaitForMultipleObjects(
     unsigned long, void *const *, int, unsigned long);
 __declspec(dllimport) int __stdcall GetOverlappedResult(void *, LPOVERLAPPED,
                                                         unsigned long *, int);
-__declspec(dllimport) int __cdecl _fileno(FILE *);
+
+#if defined(_DLL) && (_DLL == 1)
+#define SUBPROCESS_DLLIMPORT __declspec(dllimport)
+#else
+#define SUBPROCESS_DLLIMPORT
+#endif
+
+SUBPROCESS_DLLIMPORT int __cdecl _fileno(FILE *);
+SUBPROCESS_DLLIMPORT int __cdecl _open_osfhandle(subprocess_intptr_t, int);
+SUBPROCESS_DLLIMPORT subprocess_intptr_t __cdecl _get_osfhandle(int);
+
+void *__cdecl _alloca(subprocess_size_t);
 #endif
 
 #ifdef __clang__

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -89,3 +89,17 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 else()
   message(WARNING "Unknown compiler '${CMAKE_C_COMPILER_ID}'!")
 endif()
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+  add_executable(subprocess_mt_test
+    ../subprocess.h
+    utest.h
+    main.c
+    test.c
+    test.cpp
+    pre_windows.cpp
+    post_windows.cpp
+  )
+
+  target_compile_definitions(subprocess_mt_test PUBLIC "/MT")
+endif()


### PR DESCRIPTION
Also add the 2019 tests that were missing.