### PR TITLE
calling subprocess_destroy twice will cause double free

### DIFF
--- a/subprocess.h
+++ b/subprocess.h
@@ -699,27 +699,36 @@ int subprocess_join(struct subprocess_s *const process,
 int subprocess_destroy(struct subprocess_s *const process) {
   if (0 != process->stdin_file) {
     fclose(process->stdin_file);
+    process->stdin_file = 0;
   }
 
-  fclose(process->stdout_file);
+  if (0 != process->stdout_file) {
+    fclose(process->stdout_file);
 
-  if (process->stdout_file != process->stderr_file) {
-    fclose(process->stderr_file);
+    if (process->stdout_file != process->stderr_file) {
+      fclose(process->stderr_file);
+    }
+
+    process->stdout_file = 0;
+    process->stderr_file = 0;
   }
 
 #if defined(_MSC_VER)
-  CloseHandle(process->hProcess);
+  if (process->hProcess) {
+    CloseHandle(process->hProcess);
+    process->hProcess = 0;
 
-  if (0 != process->hStdInput) {
-    CloseHandle(process->hStdInput);
-  }
+    if (0 != process->hStdInput) {
+      CloseHandle(process->hStdInput);
+    }
 
-  if (0 != process->hEventOutput) {
-    CloseHandle(process->hEventOutput);
-  }
+    if (0 != process->hEventOutput) {
+      CloseHandle(process->hEventOutput);
+    }
 
-  if (0 != process->hEventError) {
-    CloseHandle(process->hEventError);
+    if (0 != process->hEventError) {
+      CloseHandle(process->hEventError);
+    }
   }
 #endif
 

--- a/test/main.c
+++ b/test/main.c
@@ -33,6 +33,20 @@ __declspec(dllimport) void __stdcall Sleep(unsigned long);
 
 #include "subprocess.h"
 
+UTEST(create, subprocess_destroy_is_idempotent) {
+  const char *const commandLine[] = {"./process_return_zero", 0};
+  struct subprocess_s process;
+  int ret = -1;
+
+  ASSERT_EQ(0, subprocess_create(commandLine, 0, &process));
+
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
+
+  ASSERT_EQ(0, subprocess_destroy(&process));
+
+  ASSERT_EQ(0, subprocess_destroy(&process));
+}
+
 UTEST(create, subprocess_return_zero) {
   const char *const commandLine[] = {"./process_return_zero", 0};
   struct subprocess_s process;


### PR DESCRIPTION
Made the subprocess_destroy method idempotent.

Unfortunately I do not have a windows system to test the MSVC branch of the change 