### PR TITLE
Allow specifying a custom environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,30 @@ Then you must use the `subprocess_read_stdout` and `subprocess_read_stderr`
 helper functions to do any reading from either pipe. Note that these calls _may_
 block if there isn't any data ready to be read.
 
+### Using a Custom Process Environment
+
+The `subprocess_create_ex` entry-point contains an additional argument
+`environment`. This argument is an array of `FOO=BAR` pairs terminating in a
+`NULL` entry:
+
+```c
+const char *command_line[] = {"echo", "\"Hello, world!\"", NULL};
+const char *environment[] = {"FOO=BAR", "HAZ=BAZ", NULL};
+struct subprocess_s subprocess;
+int result = subprocess_create_ex(command_line, 0, environment, &subprocess);
+if (0 != result) {
+  // an error occurred!
+}
+```
+
+This lets you specify custom environments for spawned subprocesses.
+
+Note though that you **cannot** specify `subprocess_option_inherit_environment`
+with a custom environment. If you want to merge some custom environment with the
+parent process environment then its up to you as the user to query the original
+parent variables you want to pass to the child, and specify them in the spawned
+process' `environment`.
+
 ## FAQs
 
 ### Why does my spawned subprocess does not have internet process?

--- a/test/main.c
+++ b/test/main.c
@@ -729,4 +729,83 @@ UTEST(create, subprocess_alive_then_join) {
   ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
+UTEST(environment, illegal_inherit_environment) {
+  const char *const commandLine[] = {"./process_return_zero", 0};
+  const char *const environment[] = {"FOO=BAR", 0};
+  struct subprocess_s process;
+
+  ASSERT_NE(0, subprocess_create_ex(commandLine,
+                                    subprocess_option_inherit_environment,
+                                    environment, &process));
+}
+
+UTEST(environment, illegal_empty_environment_with_inherit_environment) {
+  const char *const commandLine[] = {"./process_return_zero", 0};
+  const char *const environment[] = {0};
+  struct subprocess_s process;
+
+  ASSERT_NE(0, subprocess_create_ex(commandLine,
+                                    subprocess_option_inherit_environment,
+                                    environment, &process));
+}
+
+UTEST(environment, null_environment_with_inherit_environment) {
+  const char *const commandLine[] = {"./process_return_zero", 0};
+  struct subprocess_s process;
+
+  ASSERT_EQ(0, subprocess_create_ex(commandLine,
+                                    subprocess_option_inherit_environment, 0,
+                                    &process));
+
+  ASSERT_EQ(0, subprocess_destroy(&process));
+}
+
+UTEST(environment, specify_environment) {
+  const char *const commandLine[] = {"./process_inherit_environment", 0};
+  const char *const environment[] = {"PROCESS_ENV_TEST=42", 0};
+  struct subprocess_s process;
+  int ret = -1;
+
+  ASSERT_EQ(0, subprocess_create_ex(commandLine, 0, environment, &process));
+
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
+
+  ASSERT_EQ(42, ret);
+
+  ASSERT_EQ(0, subprocess_destroy(&process));
+}
+
+#ifndef _MSC_VER
+UTEST(executable_resolve, no_slashes_with_environment) {
+  const char *const commandLine[] = {"process_inherit_environment", 0};
+  const char *const environment[] = {"PROCESS_ENV_TEST=42", 0};
+  struct subprocess_s process;
+  int ret = -1;
+
+  ASSERT_EQ(0, subprocess_create_ex(commandLine, 0, environment, &process));
+
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
+
+  ASSERT_EQ(42, ret);
+
+  ASSERT_EQ(0, subprocess_destroy(&process));
+}
+
+UTEST(executable_resolve, no_slashes_with_inherit) {
+  const char *const commandLine[] = {"process_inherit_environment", 0};
+  struct subprocess_s process;
+  int ret = -1;
+
+  ASSERT_EQ(0, subprocess_create_ex(commandLine,
+                                    subprocess_option_inherit_environment, 0,
+                                    &process));
+
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
+
+  ASSERT_EQ(42, ret);
+
+  ASSERT_EQ(0, subprocess_destroy(&process));
+}
+#endif
+
 UTEST_MAIN()


### PR DESCRIPTION
This commit adds `subprocess_create_ex` which has an additional argument
`environment` that lets you specify the environment for the spawned
process.

Fixes #1.
Fixes #28.