### PR TITLE
Add support for MinGW

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,7 +2,7 @@ name: CMake
 
 on:
   push:
-    branches: [ master ]
+    branches: [ "*" ]
   pull_request:
     branches: [ master ]
 
@@ -15,7 +15,6 @@ jobs:
         compiler: [default, clang, gcc]
         exclude:
           - {os: "macOS-latest", compiler: "clang"}
-          - {os: "windows-latest", compiler: "gcc"}
           - {os: "macOS-latest", compiler: "gcc"}
           - {os: "ubuntu-latest", compiler: "default"}
           - {os: "ubuntu-latest", compiler: "default"}
@@ -27,9 +26,13 @@ jobs:
     - name: Create Build Environment
       run: cmake -E make_directory ${{github.workspace}}/build
 
-    - name: Setup dependencies
+    - name: Setup dependencies (Ubuntu)
       if: startsWith(matrix.os, 'ubuntu')
-      run: sudo apt-get install -y gcc-10 g++-10 clang-10
+      run: sudo apt-get install -y gcc-10 g++-10 clang
+
+    - name: Setup dependencies (MinGW)
+      if: matrix.compiler == 'gcc' && startsWith(matrix.os, 'windows')
+      uses: egor-tensin/setup-mingw@v2
 
     - name: Configure CMake
       shell: bash
@@ -39,15 +42,21 @@ jobs:
 
     - name: Configure CMake with GCC
       shell: bash
-      if: matrix.compiler == 'gcc'
+      if: matrix.compiler == 'gcc' && startsWith(matrix.os, 'ubuntu')
       working-directory: ${{github.workspace}}/build
       run: cmake $GITHUB_WORKSPACE/test -DCMAKE_BUILD_TYPE=${{ matrix.type }} -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
+
+    - name: Configure CMake with MinGW
+      shell: bash
+      if: matrix.compiler == 'gcc' && startsWith(matrix.os, 'windows')
+      working-directory: ${{github.workspace}}/build
+      run: cmake $GITHUB_WORKSPACE/test -DCMAKE_BUILD_TYPE=${{ matrix.type }} -G "MinGW Makefiles" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++
 
     - name: Configure CMake with Clang (Ubuntu)
       shell: bash
       if: (matrix.compiler == 'clang') && startsWith(matrix.os, 'ubuntu')
       working-directory: ${{github.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE/test -DCMAKE_BUILD_TYPE=${{ matrix.type }} -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10
+      run: cmake $GITHUB_WORKSPACE/test -DCMAKE_BUILD_TYPE=${{ matrix.type }} -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
 
     - name: Configure CMake with Clang (Windows)
       shell: bash
@@ -63,10 +72,10 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build
       shell: bash
-      run: if [ "${{ matrix.os }}" == "windows-latest" ]; then cd ${{ matrix.type }}; fi; ./subprocess_test
+      run: if [ "${{ matrix.os }}" == "windows-latest" ] && [ "${{ matrix.compiler }}" != "gcc" ]; then cd ${{ matrix.type }}; fi; ./subprocess_test
 
     - name: Test with Multithreading
       working-directory: ${{github.workspace}}/build
       shell: bash
       if: startsWith(matrix.os, 'windows')
-      run: if [ "${{ matrix.os }}" == "windows-latest" ]; then cd ${{ matrix.type }}; fi; ./subprocess_mt_test
+      run: if [ "${{ matrix.os }}" == "windows-latest" ] && [ "${{ matrix.compiler }}" != "gcc" ]; then cd ${{ matrix.type }}; fi; ./subprocess_mt_test

--- a/test/main.c
+++ b/test/main.c
@@ -811,7 +811,7 @@ UTEST(environment, specify_environment) {
   ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
-#ifndef _MSC_VER
+#if !defined(_MSC_VER)
 UTEST(executable_resolve, no_slashes_with_environment) {
   const char *const commandLine[] = {"process_inherit_environment", 0};
   const char *const environment[] = {"PROCESS_ENV_TEST=42", 0};
@@ -826,7 +826,9 @@ UTEST(executable_resolve, no_slashes_with_environment) {
 
   ASSERT_EQ(0, subprocess_destroy(&process));
 }
+#endif
 
+#if !defined(_MSC_VER) && !defined(__MINGW32__)
 UTEST(executable_resolve, no_slashes_with_inherit) {
   const char *const commandLine[] = {"process_inherit_environment", 0};
   struct subprocess_s process;
@@ -840,7 +842,9 @@ UTEST(executable_resolve, no_slashes_with_inherit) {
 
   ASSERT_EQ(42, ret);
 }
+#endif
 
+#if !defined(_MSC_VER)
 UTEST(executable_resolve, custom_search_path) {
   char current_path[4096];
   char path_var[4096 + 5];
@@ -863,7 +867,9 @@ UTEST(executable_resolve, custom_search_path) {
 
   ASSERT_EQ(0, subprocess_destroy(&process));
 }
+#endif
 
+#if !defined(_MSC_VER) && !defined(__MINGW32__)
 UTEST(executable_resolve, missing_from_path) {
   const char *const commandLine[] = {"process_call_return_argc", 0};
   struct subprocess_s process;
@@ -877,7 +883,9 @@ UTEST(executable_resolve, missing_from_path) {
 
   ASSERT_EQ(0, subprocess_destroy(&process));
 }
+#endif
 
+#if !defined(_MSC_VER)
 UTEST(executable_resolve, default_search_path) {
   const char *const commandLine[] = {"ls", 0};
   struct subprocess_s process;

--- a/test/process_call_return_argc.c
+++ b/test/process_call_return_argc.c
@@ -24,6 +24,9 @@
 // For more information, please refer to <http://unlicense.org/>
 
 #include <subprocess.h>
+#ifdef __MINGW32__
+#include <unistd.h>  // chdir
+#endif
 
 int main(int argc, const char *const argv[]) {
   const char *const commandLine[] = {"process_return_argc", "onearg", 0};

--- a/test/utest.h
+++ b/test/utest.h
@@ -66,7 +66,12 @@ typedef uint64_t utest_uint64_t;
 #define UTEST_C_FUNC
 #endif
 
-#if defined(_MSC_VER)
+#if defined(_WIN32)
+#ifdef __MINGW32__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
 typedef union {
   struct {
     unsigned long LowPart;
@@ -78,6 +83,10 @@ typedef union {
   } u;
   utest_int64_t QuadPart;
 } utest_large_integer;
+
+#ifdef __MINGW32__
+#pragma GCC diagnostic pop
+#endif
 
 UTEST_C_FUNC __declspec(dllimport) int __stdcall QueryPerformanceCounter(
     utest_large_integer *);
@@ -204,7 +213,7 @@ UTEST_C_FUNC __declspec(dllimport) int __stdcall QueryPerformanceFrequency(
 #endif
 
 static UTEST_INLINE utest_int64_t utest_ns(void) {
-#ifdef _MSC_VER
+#ifdef _WIN32
   utest_large_integer counter;
   utest_large_integer frequency;
   QueryPerformanceCounter(&counter);


### PR DESCRIPTION
This PR adds support for compilation with MinGW, and modifies the CI to also run MinGW in the test matrix to avoid regressions.

Modifications are trivial and listed here:

 * `_MSC_VER` was used to both test for MSVC and Windows. Changed it to `_WIN32` where it actually meant "check for Windows" (eg: around all usages of Windows APIs).
 * To compile MS structure definitions that use non-standard C++ code (anonymous structs in unions), it is necessary to either disable `-Wpedantic` or use `-fms-extensions`. It is my understanding that subprocess.h tries to be compatible with the strictest compile time options, so I went for scoped disabling of `-Wpedantic` via `#pragma`
 * In MinGW, weak functions are basically non-working because of weird interactions with PE/COFF. I've changed the definition of `subprocess_weak` to `static __attribute__((used))` for MinGW. Yes, it means the code gets linked multiple times, but I don't know of any other solution. Other single-file libraries opt for an external define to differentiate declaration vs definition, but since that's not the case here, it looks like duplicating code is the only solution.
 * I also did some similar changes to utest.h. I understand that utest.h is separately maintained, but I guess it can be upstreamed later if this PR is approved.
 * MSVC predefines _DLL as an empty macro instead of giving it value 1 like MSVC does. I've changed the check to cover both cases.

Some tests that are disabled for MSVC appears to pass in MinGW. Activate those.