### PR TITLE
Add CWD option to subprocess_create_ex

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,13 +158,15 @@ The `subprocess_create_ex` entry-point contains an additional argument
 const char *command_line[] = {"echo", "\"Hello, world!\"", NULL};
 const char *environment[] = {"FOO=BAR", "HAZ=BAZ", NULL};
 struct subprocess_s subprocess;
-int result = subprocess_create_ex(command_line, 0, environment, &subprocess);
+int result = subprocess_create_ex(command_line, 0, environment, NULL, &subprocess);
 if (0 != result) {
   // an error occurred!
 }
 ```
 
-This lets you specify custom environments for spawned subprocesses.
+This lets you specify custom environments for spawned subprocesses. The fourth
+argument lets you optionally specify the child process current working directory;
+pass `NULL` to inherit the parent's current working directory.
 
 Note though that you **cannot** specify `subprocess_option_inherit_environment`
 with a custom environment. If you want to merge some custom environment with the

--- a/subprocess.h
+++ b/subprocess.h
@@ -117,7 +117,7 @@ subprocess_weak int subprocess_create(const char *const command_line[],
 /// @param environment An optional array of strings for the environment to use
 /// for a child process (each element of the form FOO=BAR). The last element
 /// must be NULL to signify the end of the array.
-/// @param process_cwd The current working directory of the newly created 
+/// @param process_cwd The current working directory of the newly created
 /// process. If NULL, will be the same as the parent process.
 /// @param out_process The newly created process.
 /// @return On success zero is returned.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(process_stdout_poll process_stdout_poll.c)
 add_executable(process_stderr_poll process_stderr_poll.c)
 add_executable(process_stdout_large process_stdout_large.c)
 add_executable(process_call_return_argc process_call_return_argc.c)
+add_executable(process_cwd process_cwd.c)
 
 add_executable(subprocess_test
   ../subprocess.h

--- a/test/main.c
+++ b/test/main.c
@@ -779,8 +779,9 @@ UTEST(environment, illegal_inherit_environment) {
 
   ASSERT_NE(0, subprocess_create_ex(commandLine,
                                     subprocess_option_inherit_environment,
-                                    environment, &process,
-                                    SUBPROCESS_NULL));
+                                    environment,
+                                    SUBPROCESS_NULL,
+                                    &process));
 }
 
 UTEST(environment, illegal_empty_environment_with_inherit_environment) {
@@ -790,8 +791,9 @@ UTEST(environment, illegal_empty_environment_with_inherit_environment) {
 
   ASSERT_NE(0, subprocess_create_ex(commandLine,
                                     subprocess_option_inherit_environment,
-                                    environment, &process,
-                                    SUBPROCESS_NULL));
+                                    environment,
+                                    SUBPROCESS_NULL,
+                                    &process));
 }
 
 UTEST(environment, null_environment_with_inherit_environment) {
@@ -799,9 +801,10 @@ UTEST(environment, null_environment_with_inherit_environment) {
   struct subprocess_s process;
 
   ASSERT_EQ(0, subprocess_create_ex(commandLine,
-                                    subprocess_option_inherit_environment, 0,
-                                    &process,
-                                    SUBPROCESS_NULL));
+                                    subprocess_option_inherit_environment, 
+                                    0,
+                                    SUBPROCESS_NULL,
+                                    &process));
 
   ASSERT_EQ(0, subprocess_destroy(&process));
 }
@@ -812,7 +815,7 @@ UTEST(environment, specify_environment) {
   struct subprocess_s process;
   int ret = -1;
 
-  ASSERT_EQ(0, subprocess_create_ex(commandLine, 0, environment, &process, SUBPROCESS_NULL));
+  ASSERT_EQ(0, subprocess_create_ex(commandLine, 0, environment, SUBPROCESS_NULL, &process));
 
   ASSERT_EQ(0, subprocess_join(&process, &ret));
 
@@ -828,7 +831,7 @@ UTEST(executable_resolve, no_slashes_with_environment) {
   struct subprocess_s process;
   int ret = -1;
 
-  ASSERT_EQ(0, subprocess_create_ex(commandLine, 0, environment, &process, SUBPROCESS_NULL));
+  ASSERT_EQ(0, subprocess_create_ex(commandLine, 0, environment, SUBPROCESS_NULL, &process));
 
   ASSERT_EQ(0, subprocess_join(&process, &ret));
 
@@ -845,9 +848,10 @@ UTEST(executable_resolve, no_slashes_with_inherit) {
   int ret = -1;
 
   ASSERT_EQ(0, subprocess_create_ex(commandLine,
-                                    subprocess_option_inherit_environment, 0,
-                                    &process,
-                                    SUBPROCESS_NULL));
+                                    subprocess_option_inherit_environment, 
+                                    0,
+                                    SUBPROCESS_NULL,
+                                    &process));
 
   ASSERT_EQ(0, subprocess_join(&process, &ret));
 
@@ -870,7 +874,7 @@ UTEST(executable_resolve, custom_search_path) {
   snprintf(path_var, sizeof(path_var), "PATH=%s", current_path);
   environment[0] = path_var;
 
-  ASSERT_EQ(0, subprocess_create_ex(commandLine, 0, environment, &process, SUBPROCESS_NULL));
+  ASSERT_EQ(0, subprocess_create_ex(commandLine, 0, environment, SUBPROCESS_NULL, &process));
 
   ASSERT_EQ(0, subprocess_join(&process, &ret));
 

--- a/test/main.c
+++ b/test/main.c
@@ -779,7 +779,8 @@ UTEST(environment, illegal_inherit_environment) {
 
   ASSERT_NE(0, subprocess_create_ex(commandLine,
                                     subprocess_option_inherit_environment,
-                                    environment, &process));
+                                    environment, &process,
+                                    SUBPROCESS_NULL));
 }
 
 UTEST(environment, illegal_empty_environment_with_inherit_environment) {
@@ -789,7 +790,8 @@ UTEST(environment, illegal_empty_environment_with_inherit_environment) {
 
   ASSERT_NE(0, subprocess_create_ex(commandLine,
                                     subprocess_option_inherit_environment,
-                                    environment, &process));
+                                    environment, &process,
+                                    SUBPROCESS_NULL));
 }
 
 UTEST(environment, null_environment_with_inherit_environment) {
@@ -798,7 +800,8 @@ UTEST(environment, null_environment_with_inherit_environment) {
 
   ASSERT_EQ(0, subprocess_create_ex(commandLine,
                                     subprocess_option_inherit_environment, 0,
-                                    &process));
+                                    &process,
+                                    SUBPROCESS_NULL));
 
   ASSERT_EQ(0, subprocess_destroy(&process));
 }
@@ -809,7 +812,7 @@ UTEST(environment, specify_environment) {
   struct subprocess_s process;
   int ret = -1;
 
-  ASSERT_EQ(0, subprocess_create_ex(commandLine, 0, environment, &process));
+  ASSERT_EQ(0, subprocess_create_ex(commandLine, 0, environment, &process, SUBPROCESS_NULL));
 
   ASSERT_EQ(0, subprocess_join(&process, &ret));
 
@@ -825,7 +828,7 @@ UTEST(executable_resolve, no_slashes_with_environment) {
   struct subprocess_s process;
   int ret = -1;
 
-  ASSERT_EQ(0, subprocess_create_ex(commandLine, 0, environment, &process));
+  ASSERT_EQ(0, subprocess_create_ex(commandLine, 0, environment, &process, SUBPROCESS_NULL));
 
   ASSERT_EQ(0, subprocess_join(&process, &ret));
 
@@ -843,7 +846,8 @@ UTEST(executable_resolve, no_slashes_with_inherit) {
 
   ASSERT_EQ(0, subprocess_create_ex(commandLine,
                                     subprocess_option_inherit_environment, 0,
-                                    &process));
+                                    &process,
+                                    SUBPROCESS_NULL));
 
   ASSERT_EQ(0, subprocess_join(&process, &ret));
 
@@ -866,7 +870,7 @@ UTEST(executable_resolve, custom_search_path) {
   snprintf(path_var, sizeof(path_var), "PATH=%s", current_path);
   environment[0] = path_var;
 
-  ASSERT_EQ(0, subprocess_create_ex(commandLine, 0, environment, &process));
+  ASSERT_EQ(0, subprocess_create_ex(commandLine, 0, environment, &process, SUBPROCESS_NULL));
 
   ASSERT_EQ(0, subprocess_join(&process, &ret));
 

--- a/test/main.c
+++ b/test/main.c
@@ -25,12 +25,28 @@
 
 #include "utest.h"
 
+#include <errno.h>
+
 #if defined(_MSC_VER)
 __declspec(dllimport) void __stdcall Sleep(unsigned long);
 __declspec(dllimport) int __stdcall SetEnvironmentVariableA(const char *,
                                                             const char *);
+#endif
+
+#if defined(_WIN32)
+#include <direct.h>
+#define subprocess_test_getcwd _getcwd
+#define subprocess_test_mkdir(path) _mkdir(path)
+#define SUBPROCESS_TEST_PATH_SEPARATOR "\\"
+#define SUBPROCESS_TEST_EXE_SUFFIX ".exe"
 #else
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
+#define subprocess_test_getcwd getcwd
+#define subprocess_test_mkdir(path) mkdir(path, 0777)
+#define SUBPROCESS_TEST_PATH_SEPARATOR "/"
+#define SUBPROCESS_TEST_EXE_SUFFIX ""
 #endif
 
 #include "subprocess.h"
@@ -815,11 +831,53 @@ UTEST(environment, specify_environment) {
   struct subprocess_s process;
   int ret = -1;
 
-  ASSERT_EQ(0, subprocess_create_ex(commandLine, 0, environment, SUBPROCESS_NULL, &process));
+  ASSERT_EQ(0, subprocess_create_ex(commandLine, 0, environment,
+                                    SUBPROCESS_NULL, &process));
 
   ASSERT_EQ(0, subprocess_join(&process, &ret));
 
   ASSERT_EQ(42, ret);
+
+  ASSERT_EQ(0, subprocess_destroy(&process));
+}
+
+UTEST(create_ex, subprocess_cwd) {
+  char current_path[4096];
+  char target_path[4096];
+  char process_path[4096];
+  const char *commandLine[3];
+  struct subprocess_s process;
+  int ret = -1;
+  int written;
+
+  ASSERT_NE(NULL, subprocess_test_getcwd(current_path, sizeof(current_path)));
+
+  written = snprintf(target_path, sizeof(target_path), "%s%s%s", current_path,
+                     SUBPROCESS_TEST_PATH_SEPARATOR, "subprocess_cwd_test_dir");
+  ASSERT_TRUE(0 < written);
+  ASSERT_TRUE(written < (int)sizeof(target_path));
+
+  errno = 0;
+  if (0 != subprocess_test_mkdir(target_path)) {
+    ASSERT_EQ(EEXIST, errno);
+  }
+
+  written = snprintf(process_path, sizeof(process_path), "%s%s%s%s", current_path,
+                     SUBPROCESS_TEST_PATH_SEPARATOR, "process_cwd",
+                     SUBPROCESS_TEST_EXE_SUFFIX);
+  ASSERT_TRUE(0 < written);
+  ASSERT_TRUE(written < (int)sizeof(process_path));
+
+  commandLine[0] = process_path;
+  commandLine[1] = target_path;
+  commandLine[2] = 0;
+
+  ASSERT_EQ(0, subprocess_create_ex(commandLine, 0, SUBPROCESS_NULL,
+                                    target_path, &process));
+
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
+
+  ASSERT_EQ(0, ret);
 
   ASSERT_EQ(0, subprocess_destroy(&process));
 }

--- a/test/process_cwd.c
+++ b/test/process_cwd.c
@@ -1,0 +1,30 @@
+// This is free and unencumbered software released into the public domain.
+//
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non-commercial, and by any
+// means.
+
+#include <string.h>
+
+#if defined(_WIN32)
+#include <direct.h>
+#define subprocess_test_getcwd _getcwd
+#else
+#include <unistd.h>
+#define subprocess_test_getcwd getcwd
+#endif
+
+int main(int argc, char *argv[]) {
+  char cwd[4096];
+
+  if (argc < 2) {
+    return 1;
+  }
+
+  if (!subprocess_test_getcwd(cwd, sizeof(cwd))) {
+    return 2;
+  }
+
+  return 0 == strcmp(cwd, argv[1]) ? 0 : 3;
+}


### PR DESCRIPTION
Closes #52.

Disclaimer: I am not a posix developer. I verified the Windows code works, but did not test the UNIX stuff. I just copied this code from that issue without testing:

```cpp
  // Set working directory
  if (0 != posix_spawn_file_actions_addchdir_np(&actions, process_cwd)) {
    posix_spawn_file_actions_destroy(&actions);
    return -1;
  }
```

I did notice that there was a `posix_spawn_file_actions_addchdir_np` function (from the screenshot) and a `posix_spawn_file_actions_addchdir` function, the latter of which is "portable" and the former is "non-portable". I don't really understand what that means in this context, however when searching I did notice that Rust uses the "non-portable" variation, so I'm guessing it's the preferred one. 