### PR TITLE
fix a bug that empty strings are removed from args on Windows

### DIFF
--- a/subprocess.h
+++ b/subprocess.h
@@ -669,7 +669,8 @@ int subprocess_create_ex(const char *const commandLine[], int options,
     len++;
 
     // Quote the argument if it has a space in it
-    if (strpbrk(commandLine[i], "\t\v ") != SUBPROCESS_NULL)
+    if (strpbrk(commandLine[i], "\t\v ") != SUBPROCESS_NULL ||
+        commandLine[i][0] == SUBPROCESS_NULL)
       len += 2;
 
     for (j = 0; '\0' != commandLine[i][j]; j++) {
@@ -704,7 +705,8 @@ int subprocess_create_ex(const char *const commandLine[], int options,
       commandLineCombined[len++] = ' ';
     }
 
-    need_quoting = strpbrk(commandLine[i], "\t\v ") != SUBPROCESS_NULL;
+    need_quoting = strpbrk(commandLine[i], "\t\v ") != SUBPROCESS_NULL ||
+                   commandLine[i][0] == SUBPROCESS_NULL;
     if (need_quoting) {
       commandLineCombined[len++] = '"';
     }

--- a/test/main.c
+++ b/test/main.c
@@ -192,6 +192,30 @@ UTEST(create, subprocess_stdout_argc) {
   ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
+UTEST(create, subprocess_stdout_argc_with_empty_strings) {
+  const char *const commandLine[] = {
+      "./process_stdout_argc", "", "", "", "", 0};
+  struct subprocess_s process;
+  int ret = -1;
+  FILE *stdout_file;
+  char temp[32];
+
+  ASSERT_EQ(0, subprocess_create(commandLine, 0, &process));
+
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
+
+  ASSERT_EQ(0, ret);
+
+  stdout_file = subprocess_stdout(&process);
+  ASSERT_TRUE(stdout_file);
+
+  ASSERT_TRUE(fgets(temp, 32, stdout_file));
+
+  ASSERT_EQ(5, atoi(temp));
+
+  ASSERT_EQ(0, subprocess_destroy(&process));
+}
+
 UTEST(create, subprocess_stdout_argv) {
   const char *const commandLine[] = {
       "./process_stdout_argv", "foo", "bar", "baz", "faz", 0};


### PR DESCRIPTION
I noticed that `subprocess_create` removed empty strings from arguments on Windows.
This PR adds quotes to empty strings to pass them to commands.
It also tests `subprocess_stdout_argc` with empty strings.

