### PR TITLE
Silence -Wcast-qual warnings showing up with newer version of g++.

### DIFF
--- a/subprocess.h
+++ b/subprocess.h
@@ -804,7 +804,7 @@ int subprocess_create_ex(const char *const commandLine[], int options,
 #pragma clang diagnostic ignored "-Wcast-qual"
 #pragma clang diagnostic ignored "-Wold-style-cast"
 #endif
-    used_environment = (char *const *)environment;
+    used_environment = SUBPROCESS_CONST_CAST(char *const *, environment);
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
@@ -874,13 +874,15 @@ int subprocess_create_ex(const char *const commandLine[], int options,
   if (subprocess_option_search_user_path ==
       (options & subprocess_option_search_user_path)) {
     if (0 != posix_spawnp(&child, commandLine[0], &actions, SUBPROCESS_NULL,
-                          (char *const *)commandLine, used_environment)) {
+                          SUBPROCESS_CONST_CAST(char *const *, commandLine),
+                          used_environment)) {
       posix_spawn_file_actions_destroy(&actions);
       return -1;
     }
   } else {
     if (0 != posix_spawn(&child, commandLine[0], &actions, SUBPROCESS_NULL,
-                         (char *const *)commandLine, used_environment)) {
+                         SUBPROCESS_CONST_CAST(char *const *, commandLine),
+                         used_environment)) {
       posix_spawn_file_actions_destroy(&actions);
       return -1;
     }


### PR DESCRIPTION
Somewhen between gcc 11 and a 14 pre-release, g++ started to complain about the C-style casts:

subprocess.h: In function ‘int subprocess_create_ex(const char* const*, int, const char* const*, subprocess_s*)’: subprocess.h:877:27: warning: cast from type ‘const char* const*’ to type ‘char* const*’ casts away qualifiers [-Wcast-qual]
  877 |                           (char *const *)commandLine, used_environment)) {
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~

The pragmas for clang should not be needed anymore.