### PR TITLE
Fix subprocess_create_ex resource leak on failure

### DIFF
--- a/subprocess.h
+++ b/subprocess.h
@@ -394,6 +394,7 @@ __declspec(dllimport) int __stdcall PeekNamedPipe(void *, void *, unsigned long,
 SUBPROCESS_DLLIMPORT int __cdecl _fileno(FILE *);
 SUBPROCESS_DLLIMPORT int __cdecl _open_osfhandle(subprocess_intptr_t, int);
 SUBPROCESS_DLLIMPORT subprocess_intptr_t __cdecl _get_osfhandle(int);
+SUBPROCESS_DLLIMPORT int __cdecl _close(int);
 
 #ifndef __MINGW32__
 void *__cdecl _alloca(subprocess_size_t);
@@ -444,6 +445,18 @@ struct subprocess_s {
 
 #if defined(_WIN32)
 subprocess_weak int subprocess_create_named_pipe_helper(void **rd, void **wr);
+subprocess_weak void subprocess_close_handle(void **handle);
+void subprocess_close_handle(void **handle) {
+  const void *const invalidHandleValue =
+      SUBPROCESS_PTR_CAST(void *, ~(SUBPROCESS_CAST(subprocess_intptr_t, 0)));
+
+  if (*handle && (invalidHandleValue != *handle)) {
+    CloseHandle(*handle);
+  }
+
+  *handle = SUBPROCESS_NULL;
+}
+
 int subprocess_create_named_pipe_helper(void **rd, void **wr) {
   const unsigned long pipeAccessInbound = 0x00000001;
   const unsigned long fileFlagOverlapped = 0x40000000;
@@ -459,6 +472,9 @@ int subprocess_create_named_pipe_helper(void **rd, void **wr) {
   char name[256] = {0};
   static subprocess_tls long index = 0;
   const long unique = index++;
+
+  *rd = SUBPROCESS_NULL;
+  *wr = SUBPROCESS_NULL;
 
 #if defined(_MSC_VER) && _MSC_VER < 1900
 #pragma warning(push, 1)
@@ -487,6 +503,7 @@ int subprocess_create_named_pipe_helper(void **rd, void **wr) {
                     openExisting, fileAttributeNormal, SUBPROCESS_NULL);
 
   if (invalidHandleValue == *wr) {
+    subprocess_close_handle(rd);
     return -1;
   }
 
@@ -507,7 +524,8 @@ int subprocess_create_ex(const char *const commandLine[], int options,
 #if defined(_WIN32)
   int fd;
   int async_no_wait;
-  void *rd, *wr;
+  void *rd = SUBPROCESS_NULL;
+  void *wr = SUBPROCESS_NULL;
   char *commandLineCombined;
   subprocess_size_t len;
   int i, j;
@@ -516,7 +534,9 @@ int subprocess_create_ex(const char *const commandLine[], int options,
   const unsigned long startFUseStdHandles = 0x00000100;
   const unsigned long handleFlagInherit = 0x00000001;
   const unsigned long createNoWindow = 0x08000000;
-  struct subprocess_subprocess_information_s processInfo;
+  struct subprocess_subprocess_information_s processInfo = {SUBPROCESS_NULL,
+                                                            SUBPROCESS_NULL, 0,
+                                                            0};
   struct subprocess_security_attributes_s saAttr = {sizeof(saAttr),
                                                     SUBPROCESS_NULL, 1};
   char *used_environment = SUBPROCESS_NULL;
@@ -553,6 +573,8 @@ int subprocess_create_ex(const char *const commandLine[], int options,
   if (subprocess_option_no_window == (options & subprocess_option_no_window)) {
     flags |= createNoWindow;
   }
+
+  memset(out_process, 0, sizeof(*out_process));
 
   if (subprocess_option_inherit_environment !=
       (options & subprocess_option_inherit_environment)) {
@@ -596,51 +618,57 @@ int subprocess_create_ex(const char *const commandLine[], int options,
 
   if (!CreatePipe(&rd, &wr, SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr),
                   0)) {
-    return -1;
+    goto cleanup;
   }
 
   if (!SetHandleInformation(wr, handleFlagInherit, 0)) {
-    return -1;
+    goto cleanup;
   }
 
   fd = _open_osfhandle(SUBPROCESS_PTR_CAST(subprocess_intptr_t, wr), 0);
+  if (-1 == fd) {
+    goto cleanup;
+  }
+  wr = SUBPROCESS_NULL;
 
-  if (-1 != fd) {
-    out_process->stdin_file = _fdopen(fd, "wb");
-
-    if (SUBPROCESS_NULL == out_process->stdin_file) {
-      return -1;
-    }
+  out_process->stdin_file = _fdopen(fd, "wb");
+  if (SUBPROCESS_NULL == out_process->stdin_file) {
+    _close(fd);
+    goto cleanup;
   }
 
   startInfo.hStdInput = rd;
+  rd = SUBPROCESS_NULL;
 
   if (options & subprocess_option_enable_async) {
     if (subprocess_create_named_pipe_helper(&rd, &wr)) {
-      return -1;
+      goto cleanup;
     }
   } else {
     if (!CreatePipe(&rd, &wr,
                     SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr), 0)) {
-      return -1;
+      goto cleanup;
     }
   }
 
   if (!SetHandleInformation(rd, handleFlagInherit, 0)) {
-    return -1;
+    goto cleanup;
   }
 
   fd = _open_osfhandle(SUBPROCESS_PTR_CAST(subprocess_intptr_t, rd), 0);
+  if (-1 == fd) {
+    goto cleanup;
+  }
+  rd = SUBPROCESS_NULL;
 
-  if (-1 != fd) {
-    out_process->stdout_file = _fdopen(fd, "rb");
-
-    if (SUBPROCESS_NULL == out_process->stdout_file) {
-      return -1;
-    }
+  out_process->stdout_file = _fdopen(fd, "rb");
+  if (SUBPROCESS_NULL == out_process->stdout_file) {
+    _close(fd);
+    goto cleanup;
   }
 
   startInfo.hStdOutput = wr;
+  wr = SUBPROCESS_NULL;
 
   if (subprocess_option_combined_stdout_stderr ==
       (options & subprocess_option_combined_stdout_stderr)) {
@@ -649,30 +677,33 @@ int subprocess_create_ex(const char *const commandLine[], int options,
   } else {
     if (options & subprocess_option_enable_async) {
       if (subprocess_create_named_pipe_helper(&rd, &wr)) {
-        return -1;
+        goto cleanup;
       }
     } else {
       if (!CreatePipe(&rd, &wr,
                       SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr), 0)) {
-        return -1;
+        goto cleanup;
       }
     }
 
     if (!SetHandleInformation(rd, handleFlagInherit, 0)) {
-      return -1;
+      goto cleanup;
     }
 
     fd = _open_osfhandle(SUBPROCESS_PTR_CAST(subprocess_intptr_t, rd), 0);
+    if (-1 == fd) {
+      goto cleanup;
+    }
+    rd = SUBPROCESS_NULL;
 
-    if (-1 != fd) {
-      out_process->stderr_file = _fdopen(fd, "rb");
-
-      if (SUBPROCESS_NULL == out_process->stderr_file) {
-        return -1;
-      }
+    out_process->stderr_file = _fdopen(fd, "rb");
+    if (SUBPROCESS_NULL == out_process->stderr_file) {
+      _close(fd);
+      goto cleanup;
     }
 
     startInfo.hStdError = wr;
+    wr = SUBPROCESS_NULL;
   }
 
   if (options & subprocess_option_enable_async) {
@@ -682,6 +713,9 @@ int subprocess_create_ex(const char *const commandLine[], int options,
     out_process->hEventError =
         CreateEventA(SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr), 1, 1,
                      SUBPROCESS_NULL);
+    if (!out_process->hEventOutput || !out_process->hEventError) {
+      goto cleanup;
+    }
   } else {
     out_process->hEventOutput = SUBPROCESS_NULL;
     out_process->hEventError = SUBPROCESS_NULL;
@@ -719,7 +753,7 @@ int subprocess_create_ex(const char *const commandLine[], int options,
   commandLineCombined = SUBPROCESS_CAST(char *, _alloca(len));
 
   if (!commandLineCombined) {
-    return -1;
+    goto cleanup;
   }
 
   // Gonna re-use len to store the write index into commandLineCombined
@@ -772,15 +806,18 @@ int subprocess_create_ex(const char *const commandLine[], int options,
           SUBPROCESS_PTR_CAST(LPSTARTUPINFOA,
                               &startInfo), // STARTUPINFO pointer
           SUBPROCESS_PTR_CAST(LPPROCESS_INFORMATION, &processInfo))) {
-    return -1;
+    goto cleanup;
   }
 
   out_process->hProcess = processInfo.hProcess;
+  processInfo.hProcess = SUBPROCESS_NULL;
 
   out_process->hStdInput = startInfo.hStdInput;
+  startInfo.hStdInput = SUBPROCESS_NULL;
 
   // We don't need the handle of the primary thread in the called process.
   CloseHandle(processInfo.hThread);
+  processInfo.hThread = SUBPROCESS_NULL;
 
   if (SUBPROCESS_NULL != startInfo.hStdOutput) {
     CloseHandle(startInfo.hStdOutput);
@@ -788,19 +825,59 @@ int subprocess_create_ex(const char *const commandLine[], int options,
     if (startInfo.hStdError != startInfo.hStdOutput) {
       CloseHandle(startInfo.hStdError);
     }
+
+    startInfo.hStdOutput = SUBPROCESS_NULL;
+    startInfo.hStdError = SUBPROCESS_NULL;
   }
 
   out_process->alive = 1;
   out_process->no_wait = async_no_wait;
 
   return 0;
+
+cleanup:
+  if (out_process->stdin_file) {
+    fclose(out_process->stdin_file);
+    out_process->stdin_file = SUBPROCESS_NULL;
+  }
+
+  if (out_process->stdout_file) {
+    fclose(out_process->stdout_file);
+    if (out_process->stderr_file &&
+        (out_process->stdout_file != out_process->stderr_file)) {
+      fclose(out_process->stderr_file);
+    }
+    out_process->stdout_file = SUBPROCESS_NULL;
+    out_process->stderr_file = SUBPROCESS_NULL;
+  }
+
+  subprocess_close_handle(&rd);
+  subprocess_close_handle(&wr);
+  subprocess_close_handle(&startInfo.hStdInput);
+
+  if (startInfo.hStdOutput == startInfo.hStdError) {
+    subprocess_close_handle(&startInfo.hStdOutput);
+    startInfo.hStdError = SUBPROCESS_NULL;
+  } else {
+    subprocess_close_handle(&startInfo.hStdOutput);
+    subprocess_close_handle(&startInfo.hStdError);
+  }
+
+  subprocess_close_handle(&out_process->hEventOutput);
+  subprocess_close_handle(&out_process->hEventError);
+  subprocess_close_handle(&processInfo.hThread);
+  subprocess_close_handle(&processInfo.hProcess);
+
+  return -1;
 #else
-  int stdinfd[2];
-  int stdoutfd[2];
-  int stderrfd[2];
+  int stdinfd[2] = {-1, -1};
+  int stdoutfd[2] = {-1, -1};
+  int stderrfd[2] = {-1, -1};
   int fd, fd_flags;
   int async_no_wait;
-  pid_t child;
+  int actions_created = 0;
+  int result = -1;
+  pid_t child = 0;
   extern char **environ;
   char *const empty_environment[1] = {SUBPROCESS_NULL};
   posix_spawn_file_actions_t actions;
@@ -821,18 +898,20 @@ int subprocess_create_ex(const char *const commandLine[], int options,
     }
   }
 
+  memset(out_process, 0, sizeof(*out_process));
+
   if (0 != pipe(stdinfd)) {
-    return -1;
+    goto cleanup;
   }
 
   if (0 != pipe(stdoutfd)) {
-    return -1;
+    goto cleanup;
   }
 
   if (subprocess_option_combined_stdout_stderr !=
       (options & subprocess_option_combined_stdout_stderr)) {
     if (0 != pipe(stderrfd)) {
-      return -1;
+      goto cleanup;
     }
   }
 
@@ -854,61 +933,54 @@ int subprocess_create_ex(const char *const commandLine[], int options,
   }
 
   if (0 != posix_spawn_file_actions_init(&actions)) {
-    return -1;
+    goto cleanup;
   }
+  actions_created = 1;
 
   // Set working directory
   if (process_cwd) {
     if (0 != posix_spawn_file_actions_addchdir_np(&actions, process_cwd)) {
-      posix_spawn_file_actions_destroy(&actions);
-      return -1;
+      goto cleanup;
     }
   }
 
   // Close the stdin write end
   if (0 != posix_spawn_file_actions_addclose(&actions, stdinfd[1])) {
-    posix_spawn_file_actions_destroy(&actions);
-    return -1;
+    goto cleanup;
   }
 
   // Map the read end to stdin
   if (0 !=
       posix_spawn_file_actions_adddup2(&actions, stdinfd[0], STDIN_FILENO)) {
-    posix_spawn_file_actions_destroy(&actions);
-    return -1;
+    goto cleanup;
   }
 
   // Close the stdout read end
   if (0 != posix_spawn_file_actions_addclose(&actions, stdoutfd[0])) {
-    posix_spawn_file_actions_destroy(&actions);
-    return -1;
+    goto cleanup;
   }
 
   // Map the write end to stdout
   if (0 !=
       posix_spawn_file_actions_adddup2(&actions, stdoutfd[1], STDOUT_FILENO)) {
-    posix_spawn_file_actions_destroy(&actions);
-    return -1;
+    goto cleanup;
   }
 
   if (subprocess_option_combined_stdout_stderr ==
       (options & subprocess_option_combined_stdout_stderr)) {
     if (0 != posix_spawn_file_actions_adddup2(&actions, STDOUT_FILENO,
                                               STDERR_FILENO)) {
-      posix_spawn_file_actions_destroy(&actions);
-      return -1;
+      goto cleanup;
     }
   } else {
     // Close the stderr read end
     if (0 != posix_spawn_file_actions_addclose(&actions, stderrfd[0])) {
-      posix_spawn_file_actions_destroy(&actions);
-      return -1;
+      goto cleanup;
     }
     // Map the write end to stdout
     if (0 != posix_spawn_file_actions_adddup2(&actions, stderrfd[1],
                                               STDERR_FILENO)) {
-      posix_spawn_file_actions_destroy(&actions);
-      return -1;
+      goto cleanup;
     }
   }
 
@@ -922,15 +994,13 @@ int subprocess_create_ex(const char *const commandLine[], int options,
     if (0 != posix_spawnp(&child, commandLine[0], &actions, SUBPROCESS_NULL,
                           SUBPROCESS_CONST_CAST(char *const *, commandLine),
                           used_environment)) {
-      posix_spawn_file_actions_destroy(&actions);
-      return -1;
+      goto cleanup;
     }
   } else {
     if (0 != posix_spawn(&child, commandLine[0], &actions, SUBPROCESS_NULL,
                          SUBPROCESS_CONST_CAST(char *const *, commandLine),
                          used_environment)) {
-      posix_spawn_file_actions_destroy(&actions);
-      return -1;
+      goto cleanup;
     }
   }
 #ifdef __clang__
@@ -939,13 +1009,23 @@ int subprocess_create_ex(const char *const commandLine[], int options,
 
   // Close the stdin read end
   close(stdinfd[0]);
+  stdinfd[0] = -1;
   // Store the stdin write end
   out_process->stdin_file = fdopen(stdinfd[1], "wb");
+  if (SUBPROCESS_NULL == out_process->stdin_file) {
+    goto cleanup;
+  }
+  stdinfd[1] = -1;
 
   // Close the stdout write end
   close(stdoutfd[1]);
+  stdoutfd[1] = -1;
   // Store the stdout read end
   out_process->stdout_file = fdopen(stdoutfd[0], "rb");
+  if (SUBPROCESS_NULL == out_process->stdout_file) {
+    goto cleanup;
+  }
+  stdoutfd[0] = -1;
 
   // Set non blocking if we are async and asked not to wait.
   if (async_no_wait) {
@@ -960,8 +1040,13 @@ int subprocess_create_ex(const char *const commandLine[], int options,
   } else {
     // Close the stderr write end
     close(stderrfd[1]);
+    stderrfd[1] = -1;
     // Store the stderr read end
     out_process->stderr_file = fdopen(stderrfd[0], "rb");
+    if (SUBPROCESS_NULL == out_process->stderr_file) {
+      goto cleanup;
+    }
+    stderrfd[0] = -1;
 
     // Set non blocking if we are async and asked not to wait.
     if (async_no_wait) {
@@ -973,12 +1058,60 @@ int subprocess_create_ex(const char *const commandLine[], int options,
 
   // Store the child's pid
   out_process->child = child;
+  child = 0;
 
   out_process->alive = 1;
   out_process->no_wait = async_no_wait;
 
-  posix_spawn_file_actions_destroy(&actions);
-  return 0;
+  result = 0;
+
+cleanup:
+  if (actions_created) {
+    posix_spawn_file_actions_destroy(&actions);
+  }
+
+  if (0 != result) {
+    if (child) {
+      kill(child, 9);
+      waitpid(child, SUBPROCESS_NULL, 0);
+    }
+
+    if (out_process->stdin_file) {
+      fclose(out_process->stdin_file);
+      out_process->stdin_file = SUBPROCESS_NULL;
+    }
+
+    if (out_process->stdout_file) {
+      fclose(out_process->stdout_file);
+      if (out_process->stderr_file &&
+          (out_process->stdout_file != out_process->stderr_file)) {
+        fclose(out_process->stderr_file);
+      }
+      out_process->stdout_file = SUBPROCESS_NULL;
+      out_process->stderr_file = SUBPROCESS_NULL;
+    }
+  }
+
+  if (-1 != stdinfd[0]) {
+    close(stdinfd[0]);
+  }
+  if (-1 != stdinfd[1]) {
+    close(stdinfd[1]);
+  }
+  if (-1 != stdoutfd[0]) {
+    close(stdoutfd[0]);
+  }
+  if (-1 != stdoutfd[1]) {
+    close(stdoutfd[1]);
+  }
+  if (-1 != stderrfd[0]) {
+    close(stderrfd[0]);
+  }
+  if (-1 != stderrfd[1]) {
+    close(stderrfd[1]);
+  }
+
+  return result;
 #endif
 }
 

--- a/test/main.c
+++ b/test/main.c
@@ -34,12 +34,16 @@ __declspec(dllimport) int __stdcall SetEnvironmentVariableA(const char *,
 #endif
 
 #if defined(_WIN32)
+__declspec(dllimport) void *__stdcall GetCurrentProcess(void);
+__declspec(dllimport) int __stdcall GetProcessHandleCount(void *,
+                                                           unsigned long *);
 #include <direct.h>
 #define subprocess_test_getcwd _getcwd
 #define subprocess_test_mkdir(path) _mkdir(path)
 #define SUBPROCESS_TEST_PATH_SEPARATOR "\\"
 #define SUBPROCESS_TEST_EXE_SUFFIX ".exe"
 #else
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -50,6 +54,32 @@ __declspec(dllimport) int __stdcall SetEnvironmentVariableA(const char *,
 #endif
 
 #include "subprocess.h"
+
+static int subprocess_test_open_resource_count(void) {
+#if defined(_WIN32)
+  unsigned long count = 0;
+  if (!GetProcessHandleCount(GetCurrentProcess(), &count)) {
+    return -1;
+  }
+  return (int)count;
+#else
+  long max_fd = sysconf(_SC_OPEN_MAX);
+  long fd;
+  int count = 0;
+
+  if ((max_fd < 0) || (4096 < max_fd)) {
+    max_fd = 4096;
+  }
+
+  for (fd = 0; fd < max_fd; fd++) {
+    if (fcntl((int)fd, F_GETFD) != -1) {
+      count++;
+    }
+  }
+
+  return count;
+#endif
+}
 
 #if defined(__clang__)
 #if __has_warning("-Wunsafe-buffer-usage")
@@ -70,6 +100,29 @@ UTEST(create, subprocess_destroy_is_idempotent) {
   ASSERT_EQ(0, subprocess_destroy(&process));
 
   ASSERT_EQ(0, subprocess_destroy(&process));
+}
+
+UTEST(create_ex, subprocess_create_failure_does_not_leak_resources) {
+  const char *const commandLine[] = {
+      "./subprocess_this_command_should_not_exist", 0};
+  struct subprocess_s process;
+  int before;
+  int after;
+  int i;
+
+  before = subprocess_test_open_resource_count();
+  ASSERT_TRUE(0 <= before);
+
+  for (i = 0; i < 10; i++) {
+    memset(&process, 0, sizeof(process));
+    ASSERT_EQ(-1, subprocess_create_ex(commandLine, 0, SUBPROCESS_NULL,
+                                       SUBPROCESS_NULL, &process));
+  }
+
+  after = subprocess_test_open_resource_count();
+  ASSERT_TRUE(0 <= after);
+
+  ASSERT_EQ(before, after);
 }
 
 UTEST(create, subprocess_return_zero) {


### PR DESCRIPTION
Fixes #85.

This adds a regression test that counts open process resources before and after repeated failed `subprocess_create_ex` calls, then fixes the failure paths to clean up partially-created pipes, handles, file actions, events, and `FILE*` objects.

Notes:
- POSIX now funnels create failures through a cleanup block that closes any opened pipe FDs and destroys initialized spawn file actions.
- Windows now cleans up partially-created handles/`FILE*` objects on create failure, including `CreateProcessA` failure.
- The named-pipe helper now closes the read side if opening the write side fails.

Local verification:

```text
cmake --build build
(cd build && ./subprocess_test && ./subprocess_mt_test)
```

Both test binaries pass locally: 47/47 each.

---

🧙 Conjured by AI via [pi.dev](https://pi.dev/) using gpt-5.5