### PR TITLE
Fix building against glibc older than 2.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ pass `NULL` to inherit the parent's current working directory. On Windows,
 custom environment entries and the current working directory string are
 interpreted as UTF-8.
 
+Not every platform can honour a custom working directory. Where it cannot,
+`SUBPROCESS_HAVE_CWD` is defined to `0` and passing a non-`NULL` working
+directory fails with `ENOSYS`; this currently affects glibc older than 2.29.
+Define `SUBPROCESS_HAVE_CWD` yourself to override the detection, for instance
+on musl older than 1.1.24.
+
 Note though that you **cannot** specify `subprocess_option_inherit_environment`
 with a custom environment. If you want to merge some custom environment with the
 parent process environment then it is up to you as the user to query the original

--- a/subprocess.h
+++ b/subprocess.h
@@ -274,6 +274,18 @@ subprocess_weak int subprocess_alive(struct subprocess_s *const process);
 #include <unistd.h>
 #endif
 
+/* Whether subprocess_create_ex can honour process_cwd. glibc only gained
+   posix_spawn_file_actions_addchdir_np in 2.29. */
+#if defined(__GLIBC__)
+#if __GLIBC_PREREQ(2, 29)
+#define SUBPROCESS_HAVE_CWD 1
+#else
+#define SUBPROCESS_HAVE_CWD 0
+#endif
+#else
+#define SUBPROCESS_HAVE_CWD 1
+#endif
+
 #if defined(_WIN32)
 
 #include <wchar.h>
@@ -1207,6 +1219,8 @@ cleanup:
   if (process_cwd) {
 #if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= 260000
     posix_error = posix_spawn_file_actions_addchdir(&actions, process_cwd);
+#elif !SUBPROCESS_HAVE_CWD
+    posix_error = ENOSYS;
 #else
 #if defined(__APPLE__) && defined(__clang__)
 #pragma clang diagnostic push

--- a/subprocess.h
+++ b/subprocess.h
@@ -275,7 +275,9 @@ subprocess_weak int subprocess_alive(struct subprocess_s *const process);
 #endif
 
 /* Whether subprocess_create_ex can honour process_cwd. glibc only gained
-   posix_spawn_file_actions_addchdir_np in 2.29. */
+   posix_spawn_file_actions_addchdir_np in 2.29. Define this yourself to
+   override the detection, for instance on musl older than 1.1.24. */
+#if !defined(SUBPROCESS_HAVE_CWD)
 #if defined(__GLIBC__)
 #if __GLIBC_PREREQ(2, 29)
 #define SUBPROCESS_HAVE_CWD 1
@@ -284,6 +286,7 @@ subprocess_weak int subprocess_alive(struct subprocess_s *const process);
 #endif
 #else
 #define SUBPROCESS_HAVE_CWD 1
+#endif
 #endif
 
 #if defined(_WIN32)

--- a/test/test_shared.h
+++ b/test/test_shared.h
@@ -1116,6 +1116,7 @@ SUBPROCESS_TEST(environment, specify_environment) {
   ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
+#if SUBPROCESS_HAVE_CWD
 SUBPROCESS_TEST(create_ex, subprocess_cwd) {
   char current_path[4096];
   char target_path[4096];
@@ -1156,6 +1157,7 @@ SUBPROCESS_TEST(create_ex, subprocess_cwd) {
 
   ASSERT_EQ(0, subprocess_destroy(&process));
 }
+#endif
 
 #if !defined(_MSC_VER)
 SUBPROCESS_TEST(executable_resolve, no_slashes_with_environment) {


### PR DESCRIPTION
## Problem

`subprocess.h` does not compile on glibc older than 2.29 once `subprocess_create_ex` is
used. `posix_spawn_file_actions_addchdir_np` (added by #83, macOS branch added by #99)
only exists from glibc 2.29 onwards, and the POSIX path calls it unconditionally.

On manylinux2014 (CentOS 7, glibc 2.17, devtoolset-10 / GCC 10.2) the failure appears in
three shapes depending on the language mode:

```
C++    subprocess.h:1215: error: 'posix_spawn_file_actions_addchdir_np' was not declared in this scope
C11    subprocess.h:1215: error: implicit declaration of function ... [-Werror=implicit-function-declaration]
gnu89  ld: undefined reference to `posix_spawn_file_actions_addchdir_np'
```

The third one matters: in `gnu89` the implicit declaration is only a warning, so the
compiler is happy and the **linker** fails instead. The symbol is genuinely absent from
`libc.so`. This is therefore not the `_GNU_SOURCE` visibility issue that
`test/CMakeLists.txt` already works around — no feature-test macro can conjure a symbol
that does not exist.

Affected in practice: manylinux2014 (glibc 2.17) and manylinux_2_28 (glibc 2.28), i.e. the
standard build environments for redistributable Linux binaries. llama.cpp vendors this
header, so its manylinux jobs hit this too.

## Fix

Add a `SUBPROCESS_HAVE_CWD` compile-time probe next to the POSIX includes, and report a
requested `process_cwd` as `ENOSYS` where the platform cannot honour it. The `cwd` test is
compiled only where the capability exists.

Four deliberate choices:

- **Named after the capability, not the glibc symbol.** Users care whether they may pass a
  `cwd`, not how it is implemented.
- **Defined on every platform**, not only under `#if !defined(_WIN32)`. An undefined macro
  evaluates to 0 inside `#if`, which would have silently dropped the test on Windows.
- **Nested `#if`, not `#if defined(__GLIBC__) && !__GLIBC_PREREQ(2, 29)`.** The
  preprocessor replaces unknown identifiers with `0` before evaluating, so the flat form
  becomes `0 (2, 29)` — a syntax error on macOS, musl and Windows. `&&` does not help,
  because this fails at parse time, not evaluation time.
- **Overridable.** The detection is skipped when the macro is already defined, so platforms
  it cannot recognise are not stuck with the wrong answer. See the limitation below.

Behaviour on glibc >= 2.29 and on every non-glibc platform is byte-for-byte unchanged.
The macro is documented in `README.md` next to the `process_cwd` argument.

## Testing

Full test suite in Docker, one container per row, sanitizer probes pinned off for
reproducibility. Windows was built natively with MSVC.

| Environment | libc | Compiler | `SUBPROCESS_HAVE_CWD` | Test cases | Result |
|---|---|---|---|---|---|
| manylinux2014 | glibc 2.17 | GCC 10.2 | 0 | 423 | 405 pass, 18 fail (see below) |
| AlmaLinux 8 | glibc 2.28 | clang 21.1 | 0 | 423 | **423 pass** |
| Fedora 30 | glibc 2.29 | GCC 9.3 | 1 | header only | **builds** |
| Debian 11 | glibc 2.31 | GCC 10.2 | 1 | 432 | **432 pass** |
| Ubuntu 24.04 | glibc 2.39 | GCC 13.3 | 1 | 432 | **432 pass** |
| Ubuntu 24.04 | glibc 2.39 | clang 18.1 | 1 | 432 | **432 pass** |
| Ubuntu 24.04 | glibc 2.39 | tcc 0.9.27 | 1 | header only | **builds** |
| Alpine 3.20 | musl 1.2 | GCC 13.2 | 1 | 432 | **432 pass** |
| Alpine 3.10 | musl 1.1.22 | GCC 8.3 | 1 | header only | link error (see below) |
| Windows (cross) | — | mingw-w64 GCC 13 | 1 | compile-time assert | **holds** |
| Windows (native) | UCRT | MSVC 19.44 | 1 | 387 | **387 pass** |

Before this change, the first two rows do not build at all.

The 2.29 boundary is hit exactly: 2.28 → 0, 2.29 → 1, 2.31 → 1. The 9 `cwd` test cases are
excluded only where the function is missing — all 432 are still compiled and green
everywhere else, including musl, where the `#else` branch applies. On Windows all 9 are
present and pass; the total of 387 there is 432 minus the 45 cases (5 tests x 9 language
modes) that `test_shared.h` already excludes under `#if !defined(_MSC_VER)`.

macOS was not tested locally — CI covers it.

## Limitation: musl older than 1.1.24

musl gained `posix_spawn_file_actions_addchdir_np` in 1.1.24, so the `#else` branch is
wrong for releases before that: Alpine 3.10 (musl 1.1.22) still fails to link. musl
deliberately exposes no version macro, so this cannot be detected. That is what the
override is for — `-DSUBPROCESS_HAVE_CWD=0` builds cleanly there, verified.

## Pre-existing failures on glibc 2.17, unrelated to this change

The 18 remaining failures on manylinux2014 are `create_ex_subprocess_create_failure_preserves_error`
and `create_ex_subprocess_create_failure_does_not_leak_resources` across the 9 language
modes. They expect `subprocess_error_not_found` and get `0`.

The cause is in glibc, not in this library. A standalone probe on the same image:

```
posix_spawn  -> rc=0   child exited 127
posix_spawnp -> rc=0   child exited 127
```

Old `posix_spawn` does not report a failed `exec` back to the caller; glibc reworked this
in 2.24 — the same probe returns `rc=0` on 2.17 and 2.23, and `rc=2` on 2.24 and 2.28.
AlmaLinux 8 (glibc 2.28) shows the same `SUBPROCESS_HAVE_CWD=0` code path with
zero failures, which isolates it cleanly. These failures were simply never observable
before, because the library did not build there at all. Not addressed here.

## Also noticed

`test/CMakeLists.txt` passes `-std=c++20`, which GCC 8 (the RHEL 8 system compiler) rejects
in favour of `-std=c++2a` — the suite cannot be built with it, though the library itself
compiles fine. Not touched here; #105 fixes it separately.