### PR TITLE
Report a missing executable on glibc older than 2.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ pass `NULL` to inherit the parent's current working directory. On Windows,
 custom environment entries and the current working directory string are
 interpreted as UTF-8.
 
+Not every platform can honour a custom working directory. Where it cannot,
+`SUBPROCESS_HAVE_CWD` is defined to `0` and passing a non-`NULL` working
+directory fails with `ENOSYS`; this currently affects glibc older than 2.29.
+Define `SUBPROCESS_HAVE_CWD` yourself to override the detection, for instance
+on musl older than 1.1.24.
+
 Note though that you **cannot** specify `subprocess_option_inherit_environment`
 with a custom environment. If you want to merge some custom environment with the
 parent process environment then it is up to you as the user to query the original

--- a/subprocess.h
+++ b/subprocess.h
@@ -274,6 +274,18 @@ subprocess_weak int subprocess_alive(struct subprocess_s *const process);
 #include <unistd.h>
 #endif
 
+/* Whether subprocess_create_ex can honour process_cwd. glibc only gained
+   posix_spawn_file_actions_addchdir_np in 2.29. */
+#if defined(__GLIBC__)
+#if __GLIBC_PREREQ(2, 29)
+#define SUBPROCESS_HAVE_CWD 1
+#else
+#define SUBPROCESS_HAVE_CWD 0
+#endif
+#else
+#define SUBPROCESS_HAVE_CWD 1
+#endif
+
 #if defined(_WIN32)
 
 #include <wchar.h>
@@ -1207,6 +1219,8 @@ cleanup:
   if (process_cwd) {
 #if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= 260000
     posix_error = posix_spawn_file_actions_addchdir(&actions, process_cwd);
+#elif !SUBPROCESS_HAVE_CWD
+    posix_error = ENOSYS;
 #else
 #if defined(__APPLE__) && defined(__clang__)
 #pragma clang diagnostic push

--- a/subprocess.h
+++ b/subprocess.h
@@ -275,7 +275,9 @@ subprocess_weak int subprocess_alive(struct subprocess_s *const process);
 #endif
 
 /* Whether subprocess_create_ex can honour process_cwd. glibc only gained
-   posix_spawn_file_actions_addchdir_np in 2.29. */
+   posix_spawn_file_actions_addchdir_np in 2.29. Define this yourself to
+   override the detection, for instance on musl older than 1.1.24. */
+#if !defined(SUBPROCESS_HAVE_CWD)
 #if defined(__GLIBC__)
 #if __GLIBC_PREREQ(2, 29)
 #define SUBPROCESS_HAVE_CWD 1
@@ -284,6 +286,7 @@ subprocess_weak int subprocess_alive(struct subprocess_s *const process);
 #endif
 #else
 #define SUBPROCESS_HAVE_CWD 1
+#endif
 #endif
 
 #if defined(_WIN32)

--- a/subprocess.h
+++ b/subprocess.h
@@ -289,6 +289,20 @@ subprocess_weak int subprocess_alive(struct subprocess_s *const process);
 #endif
 #endif
 
+/* Whether posix_spawn reports a failed exec back to the caller. glibc only
+   started doing so in 2.24; before that the child silently exits with 127. */
+#if !defined(SUBPROCESS_SPAWN_REPORTS_EXEC_ERRORS)
+#if defined(__GLIBC__)
+#if __GLIBC_PREREQ(2, 24)
+#define SUBPROCESS_SPAWN_REPORTS_EXEC_ERRORS 1
+#else
+#define SUBPROCESS_SPAWN_REPORTS_EXEC_ERRORS 0
+#endif
+#else
+#define SUBPROCESS_SPAWN_REPORTS_EXEC_ERRORS 1
+#endif
+#endif
+
 #if defined(_WIN32)
 
 #include <wchar.h>
@@ -1346,6 +1360,17 @@ cleanup:
       goto cleanup;
     }
   } else {
+#if !SUBPROCESS_SPAWN_REPORTS_EXEC_ERRORS
+    /* posix_spawn cannot tell us the exec failed, so check up front */
+    if (0 != access(commandLine[0], X_OK)) {
+      saved_errno = errno;
+      result = subprocess_error_from_errno(saved_errno);
+      if (subprocess_error_unknown == result) {
+        result = subprocess_error_spawn;
+      }
+      goto cleanup;
+    }
+#endif
     posix_error = posix_spawn(&child, commandLine[0], &actions,
                               SUBPROCESS_NULL,
                               SUBPROCESS_CONST_CAST(char *const *, commandLine),

--- a/test/test_shared.h
+++ b/test/test_shared.h
@@ -1116,6 +1116,7 @@ SUBPROCESS_TEST(environment, specify_environment) {
   ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
+#if SUBPROCESS_HAVE_CWD
 SUBPROCESS_TEST(create_ex, subprocess_cwd) {
   char current_path[4096];
   char target_path[4096];
@@ -1156,6 +1157,7 @@ SUBPROCESS_TEST(create_ex, subprocess_cwd) {
 
   ASSERT_EQ(0, subprocess_destroy(&process));
 }
+#endif
 
 #if !defined(_MSC_VER)
 SUBPROCESS_TEST(executable_resolve, no_slashes_with_environment) {


### PR DESCRIPTION
Depends on #104 — without it the library does not build on any glibc old enough to show
this problem.

## Problem

On glibc older than 2.24, `posix_spawn` does not report a failed `exec` back to the
caller. `subprocess_create` therefore returns success for an executable that does not
exist, and the child quietly exits with 127. Two tests in the suite cover exactly this
and fail on such systems:

```
create_ex_subprocess_create_failure_preserves_error
create_ex_subprocess_create_failure_does_not_leak_resources
```

Across the 9 language modes that is 18 failures on manylinux2014 (glibc 2.17). They only
became visible with #104, because before that the library did not build there at all.

The behaviour is glibc's, not this library's — a standalone probe with a missing binary:

| glibc | `posix_spawn` |
|---|---|
| 2.17 | `rc=0`, child exits 127 |
| 2.23 | `rc=0`, child exits 127 |
| 2.24 | `rc=2` (ENOENT) |
| 2.28 | `rc=2` (ENOENT) |

## Fix

Add a `SUBPROCESS_SPAWN_REPORTS_EXEC_ERRORS` probe alongside `SUBPROCESS_HAVE_CWD`, and
where it is 0, check the executable with `access(..., X_OK)` before spawning. `errno` and
the returned `subprocess_error_e` then match what every supported glibc produces.

Behaviour on glibc 2.24 and newer, and on every non-glibc platform, is unchanged — the
check is not compiled there at all.

## Limitations

**Only the explicit-path branch is covered.** `posix_spawnp` resolves the executable
through `PATH`, which would mean reimplementing that search — including empty entries
meaning "current directory" and the `ENOEXEC` shell fallback. Measured on glibc 2.17 with
this patch applied:

```
posix_spawn  (explicit path): rc=-4  correct
posix_spawnp (PATH search)  : rc= 0  still unreported
```

Nobody is worse off than before, where both cases were silent, but the `PATH` case remains
wrong on those systems. Happy to extend it if you would rather have the full search.

**There is a TOCTOU window** between `access` and `posix_spawn`. On a platform whose
`posix_spawn` cannot report the failure at all, a best-effort check seemed better than
none — but it is a best-effort check, not a guarantee.

## Testing

| Environment | libc | Compiler | Result |
|---|---|---|---|
| manylinux2014 | glibc 2.17 | GCC 10.2 | **423 pass** (405 pass / 18 fail before) |
| AlmaLinux 8 | glibc 2.28 | clang 21.1 | **423 pass**, unchanged |
| Debian 11 | glibc 2.31 | GCC 10.2 | **432 pass**, unchanged |
| Ubuntu 24.04 | glibc 2.39 | GCC 13.3 | **432 pass**, unchanged |
| Ubuntu 24.04 | glibc 2.39 | clang 18.1 | **432 pass**, unchanged |
| Alpine 3.20 | musl 1.2 | GCC 13.2 | **432 pass**, unchanged |
| Windows | UCRT | MSVC 19.44 | **387 pass**, unchanged |

AlmaLinux 8 is the interesting control: glibc 2.28 is old enough to lack
`addchdir_np` but new enough to report exec failures, so the probe must be 0 for one
feature and 1 for the other — and nothing there changes.